### PR TITLE
[postgresql-wrapper] recovered jooq 3.4.4-byteafix as jooq dependency

### DIFF
--- a/torod/db-wrappers/postgresql/pom.xml
+++ b/torod/db-wrappers/postgresql/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>3.4.4</version>
+            <version>3.4.4-byteafix</version>
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>


### PR DESCRIPTION
Sync with latest jooq dependency update